### PR TITLE
Expose submodel classes under externally-facing names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Avoid circular imports that would arise during integration into `syntheseus` ([#6](https://github.com/microsoft/retrochimera/pull/6)) ([@kmaziarz])
 - Base submodel classes on `ExternalBackwardReactionModel` from `syntheseus` ([#7](https://github.com/microsoft/retrochimera/pull/7)) ([@kmaziarz])
+- Expose submodel classes under externally-facing names ([#9](https://github.com/microsoft/retrochimera/pull/9)) ([@kmaziarz])
 
 ## [1.0.0] - 2025-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Avoid circular imports that would arise during integration into `syntheseus` ([#6](https://github.com/microsoft/syntheseus/pull/6)) ([@kmaziarz])
-- Base submodel classes on `ExternalBackwardReactionModel` from `syntheseus` ([#7](https://github.com/microsoft/syntheseus/pull/7)) ([@kmaziarz])
+- Avoid circular imports that would arise during integration into `syntheseus` ([#6](https://github.com/microsoft/retrochimera/pull/6)) ([@kmaziarz])
+- Base submodel classes on `ExternalBackwardReactionModel` from `syntheseus` ([#7](https://github.com/microsoft/retrochimera/pull/7)) ([@kmaziarz])
 
 ## [1.0.0] - 2025-11-30
 

--- a/retrochimera/__init__.py
+++ b/retrochimera/__init__.py
@@ -4,6 +4,16 @@ import os
 os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
 
-from retrochimera.inference.retrochimera import RetroChimeraModel
+from retrochimera.inference import (
+    NeuralSymModel,
+    RetroChimeraDeNovoModel,
+    RetroChimeraEditModel,
+    RetroChimeraModel,
+)
 
-__all__ = ["RetroChimeraModel"]
+__all__ = [
+    "NeuralSymModel",
+    "RetroChimeraDeNovoModel",
+    "RetroChimeraEditModel",
+    "RetroChimeraModel",
+]

--- a/retrochimera/__init__.py
+++ b/retrochimera/__init__.py
@@ -5,14 +5,14 @@ os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
 
 from retrochimera.inference import (
-    NeuralSymModel,
+    BasicTemplateClassificationModel,
     RetroChimeraDeNovoModel,
     RetroChimeraEditModel,
     RetroChimeraModel,
 )
 
 __all__ = [
-    "NeuralSymModel",
+    "BasicTemplateClassificationModel",
     "RetroChimeraDeNovoModel",
     "RetroChimeraEditModel",
     "RetroChimeraModel",

--- a/retrochimera/inference/__init__.py
+++ b/retrochimera/inference/__init__.py
@@ -3,7 +3,23 @@ from retrochimera.inference.smiles_transformer import SmilesTransformerModel
 from retrochimera.inference.template_classification import TemplateClassificationModel
 from retrochimera.inference.template_localization import TemplateLocalizationModel
 
+
+class NeuralSymModel(TemplateClassificationModel):
+    pass
+
+
+class RetroChimeraDeNovoModel(SmilesTransformerModel):
+    pass
+
+
+class RetroChimeraEditModel(TemplateLocalizationModel):
+    pass
+
+
 __all__ = [
+    "NeuralSymModel",
+    "RetroChimeraDeNovoModel",
+    "RetroChimeraEditModel",
     "RetroChimeraModel",
     "SmilesTransformerModel",
     "TemplateClassificationModel",

--- a/retrochimera/inference/__init__.py
+++ b/retrochimera/inference/__init__.py
@@ -4,7 +4,7 @@ from retrochimera.inference.template_classification import TemplateClassificatio
 from retrochimera.inference.template_localization import TemplateLocalizationModel
 
 
-class NeuralSymModel(TemplateClassificationModel):
+class BasicTemplateClassificationModel(TemplateClassificationModel):
     pass
 
 
@@ -17,7 +17,7 @@ class RetroChimeraEditModel(TemplateLocalizationModel):
 
 
 __all__ = [
-    "NeuralSymModel",
+    "BasicTemplateClassificationModel",
     "RetroChimeraDeNovoModel",
     "RetroChimeraEditModel",
     "RetroChimeraModel",


### PR DESCRIPTION
Internally, RetroChimera's submodels are called `TemplateLocalizationModel` and `SmilesTransformerModel`. These names are somewhat legacy, and differ from those used in the preprint. From an external user's point of view, it may be cleaner to refer to them as `RetroChimeraEditModel` and `RetroChimeraDeNovoModel`, matching the labelling used in most plots in the paper. This PR exposes the submodels under these externally-facing names so that they can be imported as `from retrochimera import ...`. Note that the classes themselves are not renamed, as that would invalidate existing checkpoints of RetroChimera, which look up submodel classes by name. Finally, while updating `CHANGELOG.md`, I noted the PR links were broken, so I fixed those too in a separate commit.