### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-03-12
+
 ### Changed
 
 - Avoid circular imports that would arise during integration into `syntheseus` ([#6](https://github.com/microsoft/retrochimera/pull/6)) ([@kmaziarz])
@@ -17,7 +19,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 :seedling: Initial public release.
 
-[Unreleased]: https://github.com/microsoft/retrochimera/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/microsoft/retrochimera/compare/v1.1.0...HEAD
 [1.0.0]: https://github.com/microsoft/retrochimera/releases/tag/v1.0.0
+[1.1.0]: https://github.com/microsoft/retrochimera/releases/tag/v1.1.0
 
 [@kmaziarz]: https://github.com/kmaziarz


### PR DESCRIPTION
This PR edits the CHANGELOG to mark the release of `v1.1.0`. This encompasses several refactoring changes that enable easier integration into `syntheseus`.