### PR TITLE
Drop explicit TensorBoard dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Drop the explicit TensorBoard dependency ([#12](https://github.com/microsoft/retrochimera/pull/12)) ([@kmaziarz])
+
 ## [1.1.0] - 2026-03-12
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "scikit-learn",
     "syntheseus>=0.7.1",
     "syntheseus-root-aligned==0.2.0",
-    "tensorboard==2.12.0",
     "tqdm",
     "wandb==0.17.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pydantic~=2.0",
     "pyopenssl>=23.0.0",
     "scikit-learn",
-    "syntheseus>=0.7.1",
+    "syntheseus>=0.7.2",
     "syntheseus-root-aligned==0.2.0",
     "tqdm",
     "wandb==0.17.7",

--- a/retrochimera/cli/train.py
+++ b/retrochimera/cli/train.py
@@ -180,7 +180,7 @@ class TrainConfig(ModelTrainingConfig):
 
     processed_data_dir: str = MISSING  # Directory for saving preprocessed data
     checkpoint_dir: str = MISSING  # Directory to store pytorch lightning model checkpoints
-    log_dir: str = "."  # Directory to store TensorBoard logs
+    log_dir: str = "."  # Directory to store logs
     seed: int = 0  # Seed to use for all sources of randomness (Python, numpy, torch)
 
     num_processes_training: int = 1  # Number of processes to use for training


### PR DESCRIPTION
During integration with `syntheseus`, I found a conflict between the current dependency pins in RetroChimera and those of the MEGAN model: we have a strict pin of `tensorboard==2.12.0`, which is not compatible with `tensorflow==2.20.0` pinned in MEGAN. However, RetroChimera itself doesn't use TensorBoard directly anymore: we used to use it for logging, but have since switched to Weights & Biases. It is still an _indirect_ dependency through `syntheseus-root-aligned` -> `OpenNMT-py` -> `tensorboard>=2.3`; after dropping the strict pin in `pyproject.toml`, the dependency resolver can choose whatever works for MEGAN and OpenNMT (in this case, the newest `2.20.0` is fine).

Also, I raise the minimum version of `syntheseus` to `0.7.2`, to pull in a recent checkpoint downloading bugfix from `0.7.2`.