### PR TITLE
Fix `weakref` bug preventing garbage collection of template-based models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Expose setting `num_processes` for template-based models ([#13](https://github.com/microsoft/retrochimera/pull/13)) ([@kmaziarz])
 
+### Fixed
+
+- Fix `weakref` bug preventing garbage collection of template-based models ([#14](https://github.com/microsoft/retrochimera/pull/14)) ([@kmaziarz])
+
 ## [1.1.0] - 2026-03-12
 
 ### Changed

--- a/retrochimera/chem/rule_application_server.py
+++ b/retrochimera/chem/rule_application_server.py
@@ -139,16 +139,6 @@ class RuleApplicationServer:
             args=(data,),
         )
 
-    def _connection_try_recv(self, process_id: int, restart_on_failure: bool) -> Any:
-        return self._connection_try_call(
-            process_id=process_id, restart_on_failure=restart_on_failure, fn_name="recv", args=()
-        )
-
-    def _connection_try_close(self, process_id: int) -> None:
-        self._connection_try_call(
-            process_id=process_id, restart_on_failure=False, fn_name="close", args=()
-        )
-
     @staticmethod
     def _finalize_server(processes: dict[int, Process], connections: dict[int, Connection]) -> None:
         """Clean up worker processes. Must not reference `self` to allow garbage collection."""

--- a/retrochimera/chem/rule_application_server.py
+++ b/retrochimera/chem/rule_application_server.py
@@ -94,8 +94,11 @@ class RuleApplicationServer:
             # Block until the process has loaded its chunk of the rulebase.
             self._connections[process_id].recv()
 
-        # Register the `close` method to be called when the server object is garbage collected.
-        weakref.finalize(self, self.close)
+        # Register cleanup to run when this server object is garbage collected. We cannot pass a
+        # bound method (`self.close`) as it contains a reference to `self` which would prevent GC.
+        weakref.finalize(
+            self, RuleApplicationServer._finalize_server, self._processes, self._connections
+        )
 
     def _start_processes(self, process_ids: list[int]) -> None:
         for process_id in process_ids:
@@ -146,33 +149,45 @@ class RuleApplicationServer:
             process_id=process_id, restart_on_failure=False, fn_name="close", args=()
         )
 
-    def _close_processes(self, process_ids: list[int]) -> None:
-        # Filter out processes that are already closed.
-        process_ids = [process_id for process_id in process_ids if process_id in self._processes]
-
-        for process_id in process_ids:
-            self._connection_try_send(process_id=process_id, restart_on_failure=False, data=None)
-
-        for process_id in process_ids:
-            # First wait to see if the process finishes gracefully; if not, SIGTERM it.
-            self._processes[process_id].join(timeout=2.0)
-            self._processes[process_id].terminate()
-
-        for process_id in process_ids:
-            self._processes[process_id].join(timeout=2.0)
-
-        for process_id in process_ids:
+    @staticmethod
+    def _finalize_server(processes: dict[int, Process], connections: dict[int, Connection]) -> None:
+        """Clean up worker processes. Must not reference `self` to allow garbage collection."""
+        for process_id in processes:
             try:
-                self._processes[process_id].close()
+                connections[process_id].send(None)
+            except (ConnectionResetError, BrokenPipeError, OSError):
+                pass
+
+        for process_id in processes:
+            # First wait to see if the process finishes gracefully; if not, SIGTERM it.
+            processes[process_id].join(timeout=2.0)
+            processes[process_id].terminate()
+
+        for process_id in processes:
+            processes[process_id].join(timeout=2.0)
+
+        for process_id in processes:
+            try:
+                processes[process_id].close()
             except ValueError as e:
                 logger.warning(
                     f"Error trying to close a rule application process {process_id}: {e}"
                 )
 
-            self._connection_try_close(process_id=process_id)
+            try:
+                connections[process_id].close()
+            except Exception:
+                pass
 
-            del self._processes[process_id]
-            del self._connections[process_id]
+    def _close_processes(self, process_ids: list[int]) -> None:
+        process_ids = [process_id for process_id in process_ids if process_id in self._processes]
+        if not process_ids:
+            return
+
+        # Extract into separate dicts and delegate to the static cleanup method.
+        sub_processes = {pid: self._processes.pop(pid) for pid in process_ids}
+        sub_connections = {pid: self._connections.pop(pid) for pid in process_ids}
+        RuleApplicationServer._finalize_server(sub_processes, sub_connections)
 
     def _close_all_processes(self) -> None:
         self._close_processes(list(range(self._num_processes)))

--- a/tests/chem/test_rule_application_server.py
+++ b/tests/chem/test_rule_application_server.py
@@ -1,5 +1,7 @@
+import gc
 import random
 import tempfile
+from multiprocessing import active_children
 
 import pytest
 from syntheseus.reaction_prediction.data.reaction_sample import ReactionSample
@@ -46,3 +48,18 @@ def test_apply_rules(reaction_dataset: ReactionDataset, num_inputs: int, num_pro
             results_naive.extend(get_products(input, rule=reaction_dataset.rulebase[rule_id].rxn))
 
         assert sum(results, []) == results_naive
+
+
+def test_processes_cleaned_up_on_gc(tiny_rulebase):
+    """Verify that worker processes are cleaned up when the server is garbage collected."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        tiny_rulebase.save_to_file(dir=temp_dir)
+        server = RuleApplicationServer(rulebase_dir=temp_dir, num_processes=1)
+
+    workers_before = set(active_children())
+    assert len(workers_before) >= 1
+
+    del server
+    gc.collect()
+
+    assert not workers_before & set(active_children())


### PR DESCRIPTION
Our template-based models rely on `RuleApplicationServer`, which spins up parallel processes for template application. When the server is garbage-collected (for example, because one calls `del` on the enclosing model), those processes should be terminated, and we tried to ensure this by using `weakref.finalize` to register `self.close` to be called. However, this has a fundamental bug: `self.close` contains a reference to `self`, thus a reference to `self` will exist even after doing `del` on the model, so the server can _never_ be garbage collected; the processes are only killed when Python itself shuts down.

This PR fixes the bug by moving the cleanup logic to a `staticmethod` instead. It also adds a test to verify the processes are cleaned up; before the bugfix commit the test does fail.

For a minimal illustration of the bug, compare

```python
import weakref

class Server:
    def close(self):
        print("close() called")

    def __init__(self):
        weakref.finalize(self, self.close)

server = Server()

print("before del")
del server
print("after del")

# close is called at the end of script
```

with the fixed version relying on a static method

```python
import weakref

class Server:
    @staticmethod
    def static_close():
        print(f"static_close() called")

    def __init__(self):
        weakref.finalize(self, Server.static_close)

server = Server()

print("before del")
del server  # close is immediately called here
print("after del")
```

We did not find this issue before, as in most cases we load a single model, use it throughout some workflow, and then the script ends. The issue manifests itself when one uses a few models within one script, and calls `del` in between in an attempt to free memory. With the changes here, this now works as expected (i.e. memory used by the model is recovered on `del`).