### PR TITLE
Speed up localization model loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Speed up localization model loading ([#15](https://github.com/microsoft/retrochimera/pull/15)) ([@kmaziarz])
 - Drop the explicit TensorBoard dependency ([#12](https://github.com/microsoft/retrochimera/pull/12)) ([@kmaziarz])
 
 ### Added

--- a/retrochimera/inference/template_localization.py
+++ b/retrochimera/inference/template_localization.py
@@ -49,12 +49,12 @@ class TemplateLocalizationModel(RuleBasedRetrosynthesizer, ExternalBackwardReact
         assert self.model.all_rewrites_atom_outputs is not None
         assert self.model.all_rewrites_batch_idx is not None
 
-        # Unpack the rewrite atom outputs for convenience.
-        self.all_rewrites_atom_outputs_list: list[torch.Tensor] = []
-        for rule_id in range(self.model.n_classes):
-            self.all_rewrites_atom_outputs_list.append(
-                self.model.all_rewrites_atom_outputs[self.model.all_rewrites_batch_idx == rule_id]
-            )
+        # Unpack the rewrite atom outputs by rule ID. The `batch_idx` tensor is sorted, so we find
+        # group boundaries with `unique_consecutive` and then split.
+        _, counts = torch.unique_consecutive(self.model.all_rewrites_batch_idx, return_counts=True)
+        self.all_rewrites_atom_outputs_list: list[torch.Tensor] = list(
+            torch.split(self.model.all_rewrites_atom_outputs, counts.tolist())
+        )
 
     @property
     def _rule_application_server_kwargs(self) -> dict[str, Any]:


### PR DESCRIPTION
When loading a `TemplateLocalizationModel`, we load and unpack rewrite atom outputs from the checkpoint file. The current code does it very inefficiently using a `for` loop; this is particularly problematic without GPU acceleration where currently model loading can take even several minutes.

This PR improves this by using appropriate `torch` primitives instead. In my local tests, model loading time decreased to ~27s on both CPU and GPU, while before the change it took ~100s on CPU and ~55s on GPU. In either case, unpacking `all_rewrites_atom_outputs_list` used to be a non-trivial contribution, but now it takes less than a second.