### PR TITLE
Speed up localization score computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Speed up localization model loading ([#15](https://github.com/microsoft/retrochimera/pull/15)) ([@kmaziarz])
+- Speed up localization model ([#15](https://github.com/microsoft/retrochimera/pull/15), [#16](https://github.com/microsoft/retrochimera/pull/16)) ([@kmaziarz])
 - Drop the explicit TensorBoard dependency ([#12](https://github.com/microsoft/retrochimera/pull/12)) ([@kmaziarz])
 
 ### Added

--- a/retrochimera/inference/template_localization.py
+++ b/retrochimera/inference/template_localization.py
@@ -99,21 +99,25 @@ class TemplateLocalizationModel(RuleBasedRetrosynthesizer, ExternalBackwardReact
             get_sorted_ids_and_probs(batch_rule_logits, k=top_k)
         ):
             input_graph_atom_outputs = torch.t(input_graphs_atom_outputs[input_graphs.batch == idx])
+
+            lhs_chunks = [self.all_rewrites_atom_outputs_list[rule_id] for rule_id in rule_ids]
+            chunk_sizes = [c.size(0) for c in lhs_chunks]
+
+            all_scores = torch.mm(torch.cat(lhs_chunks, dim=0), input_graph_atom_outputs)
+            all_scores = torch.nn.functional.log_softmax(all_scores, dim=-1)
+            all_scores_list = tensor_to_list(all_scores)
+
+            offset = 0
             graph_results = []
-
-            for rule_id, rule_prob in zip(rule_ids, rule_probs):
-                localization_scores = torch.mm(
-                    self.all_rewrites_atom_outputs_list[rule_id], input_graph_atom_outputs
-                )
-                localization_scores = torch.nn.functional.log_softmax(localization_scores, dim=-1)
-
+            for rule_id, rule_prob, chunk_size in zip(rule_ids, rule_probs, chunk_sizes):
                 graph_results.append(
                     RulePrediction(
                         id=rule_id,
                         prob=rule_prob,
-                        localization_scores=tensor_to_list(localization_scores),
+                        localization_scores=all_scores_list[offset : offset + chunk_size],
                     )
                 )
+                offset += chunk_size
 
             results.append(graph_results)
 


### PR DESCRIPTION
In the localization model, a non-trivial amount of time is spent on computing localization scores. This is done by performing matrix multiplications of product atom representations and LHS atom representations for top templates. So far, this was done using a `for` loop over the templates. Instead, one can concatenate all LHS atom representations across selected templates, do a single `torch.mm`, and then unpack; empirically, this can reduce end-to-end inference time by up to 25%. Model outputs are unchanged (modulo tiny variation that can be explained by inherent GPU randomness).

By default, we apply quite a lot of templates (`num_templates_per_result=10`, `max_cumulative_prob=1.0`), this is where the impact of this change is greatest. With more restricted settings (`num_templates_per_result=1`, `max_cumulative_prob=0.995`) speedup is smaller, but still there. With larger batch size, per-molecule time is reduced, but the relative speedup is unchanged.

| Setting                       | Before (ms/mol) | After (ms/mol) | Speedup |
| ----------------------------- | --------------: | -------------: | :-----: |
| batch_size=1  (default)       |         303.203 |        229.721 |  1.32x  |
| batch_size=1  (few templates) |          63.172 |         57.679 |  1.10x  |
| batch_size=16 (default)       |         245.640 |        180.541 |  1.36x  |
| batch_size=16 (few templates) |          38.513 |         32.982 |  1.17x  |