### PR TITLE
Add support for model finetuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add support for model finetuning ([#21](https://github.com/microsoft/retrochimera/pull/21)) ([@kmaziarz])
+
 ## [1.2.0] - 2026-06-17
 
 ### Changed

--- a/retrochimera/README.md
+++ b/retrochimera/README.md
@@ -61,6 +61,9 @@ This step converts the data further into a featurized form ready for training. T
 In this step one trains a model on the featurized data from previous step. Model class and other hyperparameters set here must match those set during preprocessing. By default training will proceed for several epochs, saving checkpoints along the way, and then average out a set of best checkpoints to form `combined.ckpt`.
 Settings used for the provided checkpoints can be found under `retrochimera/cli/config`, and are accessed by setting the `preset` argument.
 
+One can also set `finetune_checkpoint_path` to warm-start training starting from a pretrained checkpoint.
+Template library and SMILES token vocabulary do not have to be the same between pretraining and finetuning, as the layers relating to those are always reinitialized.
+
 # Ensembling
 
 - Input: `*.json` files containing dumped model outputs on validation and train set

--- a/retrochimera/cli/train.py
+++ b/retrochimera/cli/train.py
@@ -31,8 +31,12 @@ from retrochimera.models.template_classification import MCCModel
 from retrochimera.models.template_localization import TemplateLocalizationModel
 from retrochimera.utils.logging import get_logger
 from retrochimera.utils.misc import convert_camel_to_snake, lookup_by_name
-from retrochimera.utils.pytorch_lightning import ModelCheckpoint, OptLRMonitor
-from retrochimera.utils.training import average_checkpoints
+from retrochimera.utils.pytorch_lightning import ModelCheckpoint, OptLRMonitor, UnfreezeCallback
+from retrochimera.utils.training import (
+    average_checkpoints,
+    freeze_pretrained_layers,
+    load_pretrained_weights,
+)
 
 logger = get_logger(__name__)
 
@@ -46,6 +50,12 @@ Required arguments:
   preset              Selects a configuration from 'pistachio' (default), 'uspto_full', 'uspto_50k'.
   processed_data_dir  Directory containing the processed data.
   checkpoint_dir      Directory where model checkpoints will be saved.
+
+Optional arguments:
+  finetune_checkpoint_path  Path to a pretrained checkpoint for fine-tuning. When specified,
+                            the model will load transferable weights from this checkpoint and
+                            freeze them, training only the vocabulary-dependent layers (e.g.,
+                            token embeddings, output projections, template-specific parameters).
 
 Optionally you can provide one or several paths to YAML config files to override the preset via the
 'config' argument. Any config key can also be overridden directly from the CLI with key=value pairs.
@@ -185,6 +195,10 @@ class TrainConfig(ModelTrainingConfig):
 
     num_processes_training: int = 1  # Number of processes to use for training
 
+    # Fine-tuning options
+    finetune_checkpoint_path: Optional[str] = None  # Path to pretrained checkpoint for fine-tuning
+    finetuning_warmup_epochs: int = 1  # Number of epochs to keep pretrained weights frozen
+
 
 @dataclass
 class TrainingResult:
@@ -193,7 +207,11 @@ class TrainingResult:
 
 
 def train(
-    model: AbstractModel, data_path: Union[str, Path], config: TrainConfig, model_config: Any
+    model: AbstractModel,
+    data_path: Union[str, Path],
+    config: TrainConfig,
+    model_config: Any,
+    frozen_param_names: Optional[set[str]] = None,
 ) -> TrainingResult:
     data_loader_kwargs = {
         "batch_size": model_config.training.batch_size,
@@ -250,6 +268,14 @@ def train(
         )
 
         callbacks = [best_checkpoint_callback, last_checkpoint_callback]
+
+    # Add callback to unfreeze pretrained weights after warmup epochs
+    if frozen_param_names is not None:
+        unfreeze_callback = UnfreezeCallback(
+            frozen_param_names=frozen_param_names,
+            warmup_epochs=config.finetuning_warmup_epochs,
+        )
+        callbacks.append(unfreeze_callback)
 
     checkpoint_dir = Path(config.checkpoint_dir)
     checkpoint_dir_contents = list(checkpoint_dir.iterdir())
@@ -546,12 +572,35 @@ def main() -> None:
         rulebase_dir=checkpoint_dir,
     )
 
+    # Handle fine-tuning from a pretrained checkpoint
+    if config.finetune_checkpoint_path is not None:
+        logger.info(f"Fine-tuning is enabled from checkpoint: {config.finetune_checkpoint_path}")
+
+        # Get the list of non-transferable parameter prefixes from the model
+        nontransferable_prefixes = model.get_nontransferable_param_prefixes()
+        logger.info(f"Non-transferable parameter prefixes: {nontransferable_prefixes}")
+
+        # Load pretrained weights, skipping non-transferable ones. If we're resuming from a
+        # checkpoint, `trainer.fit()` will overwrite these with the checkpoint weights, but the
+        # freezing pattern remains correct.
+        loaded_params = load_pretrained_weights(
+            model=model,
+            checkpoint_path=config.finetune_checkpoint_path,
+            nontransferable_prefixes=nontransferable_prefixes,
+        )
+
+        # Freeze the pretrained parameters
+        freeze_pretrained_layers(model=model, loaded_param_names=loaded_params)
+    else:
+        loaded_params = None
+
     logger.info("Starting training")
     train(
         model=model,
         data_path=str(processed_data_dir / "data.h5"),
         config=config,
         model_config=model_config,
+        frozen_param_names=loaded_params,
     )
 
 

--- a/retrochimera/models/lightning.py
+++ b/retrochimera/models/lightning.py
@@ -98,6 +98,13 @@ class AbstractModel(
     ) -> Iterable[ProcessedSampleType]:
         pass
 
+    def get_nontransferable_param_prefixes(self) -> list[str]:
+        """Get prefixes for parameters that should not be transferred during fine-tuning.
+
+        These are typically parameters that depend on vocab or template library size.
+        """
+        return []
+
     @abstractmethod
     def collate(self, samples: list[ProcessedSampleType]) -> BatchType:
         pass

--- a/retrochimera/models/smiles_transformer.py
+++ b/retrochimera/models/smiles_transformer.py
@@ -699,3 +699,11 @@ class SmilesTransformerModel(AbstractModel[SmilesReactionSample, ProcessedSample
     def set_rulebase(self, rulebase: RuleBase, rulebase_dir: Union[str, Path]) -> None:
         # Inherited from other template-based models (Not used in this model now)
         self.rulebase_dir = rulebase_dir
+
+    def get_nontransferable_param_prefixes(self) -> list[str]:
+        prefixes = ["token_fc."]
+        if self.share_encoder_decoder_input_embedding:
+            prefixes.append("token_embedding.")
+        else:
+            prefixes.extend(["encoder_token_embedding.", "decoder_token_embedding."])
+        return prefixes

--- a/retrochimera/models/template_classification.py
+++ b/retrochimera/models/template_classification.py
@@ -107,3 +107,8 @@ class MCCModel(AbstractModel[TemplateReactionSample, ProcessedSample, Batch]):
             inputs=self.encoder.collate([sample.input for sample in samples]),
             targets=torch.as_tensor([sample.target for sample in samples], dtype=torch.long),
         )
+
+    def get_nontransferable_param_prefixes(self) -> list[str]:
+        # Extract the index of the last linear layer, which is the one that depends on `n_classes`
+        output_layer_idx = 3 * (self.n_hidden_layers + 1)
+        return [f"mlp.mlp.{output_layer_idx}."]

--- a/retrochimera/models/template_localization.py
+++ b/retrochimera/models/template_localization.py
@@ -557,3 +557,19 @@ class TemplateLocalizationModel(AbstractModel[TemplateReactionSample, ProcessedS
                 "all_rewrites_atom_outputs",
             ]:
                 checkpoint[key] = getattr(self, key).detach().cpu()
+
+    def get_nontransferable_param_prefixes(self) -> list[str]:
+        prefixes = [
+            "free_rewrite_embeddings",
+            "all_rewrites_batch_idx",
+            "all_rewrites_mol_outputs",
+            "all_rewrites_atom_outputs",
+        ]
+
+        # Add rewrite_encoder's non-transferable prefixes
+        if self.rewrite_encoder.atom_categorical_features_emb is not None:
+            prefixes.append("rewrite_encoder.atom_categorical_features_emb.")
+        else:
+            prefixes.append("rewrite_encoder.gnn.convs.0.")
+
+        return prefixes

--- a/retrochimera/utils/pytorch_lightning.py
+++ b/retrochimera/utils/pytorch_lightning.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import pytorch_lightning as pl
 from pytorch_lightning import callbacks as pl_callbacks
 from pytorch_lightning.callbacks import Callback
 
@@ -64,3 +65,28 @@ class ModelCheckpoint(pl_callbacks.ModelCheckpoint):
                 state_dict[key] = new_value
 
         super().load_state_dict(state_dict)
+
+
+class UnfreezeCallback(Callback):
+    """Callback to unfreeze pretrained parameters after warmup epochs."""
+
+    def __init__(self, frozen_param_names: set[str], warmup_epochs: int) -> None:
+        self.frozen_param_names = frozen_param_names
+        self.warmup_epochs = warmup_epochs
+        self._unfrozen = False
+
+    def on_train_epoch_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        if self._unfrozen:
+            return
+
+        if trainer.current_epoch >= self.warmup_epochs:
+            unfrozen_count = 0
+            for name, param in pl_module.named_parameters():
+                if name in self.frozen_param_names:
+                    param.requires_grad = True
+                    unfrozen_count += param.numel()
+
+            logger.info(
+                f"Epoch {trainer.current_epoch}: Unfroze {unfrozen_count:,} pretrained parameters"
+            )
+            self._unfrozen = True

--- a/retrochimera/utils/training.py
+++ b/retrochimera/utils/training.py
@@ -91,3 +91,77 @@ def average_checkpoints(input_paths: list[Union[str, Path]], output_path: Union[
 
     with open(output_path, "wb") as f:
         torch.save(combined_checkpoint, f)
+
+
+def load_pretrained_weights(
+    model: AbstractModel, checkpoint_path: Union[str, Path], nontransferable_prefixes: list[str]
+) -> set[str]:
+    """Load pretrained weights into a model, skipping non-transferable parameters.
+
+    Args:
+        model: The model to load weights into.
+        checkpoint_path: Path to the pretrained checkpoint file.
+        nontransferable_prefixes: List of parameter name prefixes to skip.
+
+    Returns:
+        Set of parameter names that were successfully loaded.
+    """
+    with open(checkpoint_path, "rb") as f:
+        checkpoint = torch.load(f, map_location="cpu")
+
+    pretrained_state_dict = checkpoint["state_dict"]
+    model_state_dict = model.state_dict()
+
+    loaded_keys: set[str] = set()
+    skipped_prefix_keys: set[str] = set()
+
+    for key in pretrained_state_dict.keys():
+        should_skip = any(key.startswith(prefix) for prefix in nontransferable_prefixes)
+        if should_skip:
+            skipped_prefix_keys.add(key)
+            continue
+
+        model_state_dict[key] = pretrained_state_dict[key]
+        loaded_keys.add(key)
+
+    # Load the modified state dict
+    model.load_state_dict(model_state_dict)
+
+    logger.info("Loaded %d parameters from pretrained checkpoint", len(loaded_keys))
+    if skipped_prefix_keys:
+        logger.info(
+            "Skipped %d parameters due to non-transferable prefixes", len(skipped_prefix_keys)
+        )
+
+    return loaded_keys
+
+
+def freeze_pretrained_layers(model: AbstractModel, loaded_param_names: set[str]) -> None:
+    """Freeze parameters that were loaded from a pretrained checkpoint.
+
+    This sets `requires_grad=False` for all parameters that were successfully loaded, so that only
+    the non-transferred (newly initialized) parameters will be trained.
+
+    Args:
+        model: The model whose parameters to freeze.
+        loaded_param_names: Set of parameter names that were loaded from pretrained checkpoint.
+    """
+    frozen_count = 0
+    trainable_count = 0
+
+    for name, param in model.named_parameters():
+        if name in loaded_param_names:
+            param.requires_grad = False
+            frozen_count += param.numel()
+        elif param.requires_grad:
+            trainable_count += param.numel()
+        else:
+            # This parameter was not loaded but is already frozen, which is unusual and worth logging
+            logger.warning(
+                "Parameter %s was not loaded from pretrained checkpoint, but is already frozen",
+                name,
+            )
+
+    logger.info(
+        f"Froze {frozen_count:,} pretrained parameters, {trainable_count:,} parameters remain trainable"
+    )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -110,7 +110,7 @@ def test_augment_rsmiles(processed_output_dir: Path, augmented_output_dir: Path)
         ],
     )
 
-    for (path_input, path_output) in [
+    for path_input, path_output in [
         (processed_output_dir / "train.jsonl", augmented_output_dir / "train" / "train.jsonl"),
         (processed_output_dir / "val.jsonl", augmented_output_dir / "val" / "val.jsonl"),
     ]:
@@ -168,6 +168,7 @@ def test_preprocess_and_train(
     extra_model_kwargs: dict[str, Any],
     tmp_path: Path,
     processed_output_dir: Path,
+    split_output_dir: Path,
 ) -> None:
     """Test the end-to-end reaction prediction pipeline for various model classes."""
     model_class = testcase.split("[")[0]
@@ -232,29 +233,9 @@ def test_preprocess_and_train(
     # Append any extra, test-specific kwargs.
     model_kwargs.extend([f"{train_config_key}.{k}={v}" for k, v in extra_model_kwargs.items()])
 
-    preprocess_args = model_kwargs + [
-        f"data_dir={processed_output_dir}",
-        f"processed_data_dir={featurized_output_dir}",
-        "rulebase_min_rule_support=2",
-        "num_processes_preprocessing=1",
-    ]
-
-    n_epochs = 450 if model_class == "SmilesTransformer" else 200
-    train_args = model_kwargs + [
-        f"processed_data_dir={featurized_output_dir}",
-        f"checkpoint_dir={checkpoint_dir}",
-        f"log_dir={log_dir}",
-        f"{train_config_key}.training.n_epochs={n_epochs}",
-        f"{train_config_key}.training.learning_rate=0.001",
-        f"{train_config_key}.training.learning_rate_decay_step_size={n_epochs // 2}",
-        f"{train_config_key}.training.check_val_every_n_epoch=50",
-        f"{train_config_key}.training.num_checkpoints_for_averaging=2",
-        f"{train_config_key}.training.accelerator=cpu",
-        f"{train_config_key}.training.gradient_clip_val=50.0",
-        f"{train_config_key}.training.accumulate_grad_batches=1",
-    ]
-
     extra_args = []
+    vocab_args: list[str] = []
+
     if model_class == "SmilesTransformer":
         featurized_output_dir.mkdir()
         vocab_output_path = featurized_output_dir / "vocab.txt"
@@ -266,21 +247,66 @@ def test_preprocess_and_train(
 
         assert vocab_output_path.exists()
 
-        vocab_arg = f"{train_config_key}.vocab_path={vocab_output_path}"
-        train_args += [vocab_arg]
-        preprocess_args += [vocab_arg]
+        # Reuse the same vocabulary across pretraining and fine-tuning preprocessing/training.
+        vocab_args = [f"{train_config_key}.vocab_path={vocab_output_path}"]
 
         # We did not apply augmentation to the training data, so turn it off for eval.
         extra_args += ["model_kwargs={'augmentation_size': 1}"]
 
-    run_with_python(path="./retrochimera/cli/preprocess.py", args=preprocess_args)
+    n_epochs = 450 if model_class == "SmilesTransformer" else 200
+
+    def run_preprocess(data_dir: Path, processed_data_dir: Path) -> None:
+        run_with_python(
+            path="./retrochimera/cli/preprocess.py",
+            args=(
+                model_kwargs
+                + [
+                    f"data_dir={data_dir}",
+                    f"processed_data_dir={processed_data_dir}",
+                    "rulebase_min_rule_support=2",
+                    "num_processes_preprocessing=1",
+                ]
+                + vocab_args
+            ),
+        )
+
+    def run_train(
+        processed_data_dir: Path,
+        checkpoint_dir: Path,
+        log_dir: Path,
+        check_val_every_n_epoch: int = 50,
+        extra: Optional[list[str]] = None,
+    ) -> None:
+        run_with_python(
+            path="./retrochimera/cli/train.py",
+            args=(
+                model_kwargs
+                + [
+                    f"processed_data_dir={processed_data_dir}",
+                    f"checkpoint_dir={checkpoint_dir}",
+                    f"log_dir={log_dir}",
+                    f"{train_config_key}.training.n_epochs={n_epochs}",
+                    f"{train_config_key}.training.learning_rate=0.001",
+                    f"{train_config_key}.training.learning_rate_decay_step_size={n_epochs // 2}",
+                    f"{train_config_key}.training.check_val_every_n_epoch={check_val_every_n_epoch}",
+                    f"{train_config_key}.training.num_checkpoints_for_averaging=2",
+                    f"{train_config_key}.training.accelerator=cpu",
+                    f"{train_config_key}.training.gradient_clip_val=50.0",
+                    f"{train_config_key}.training.accumulate_grad_batches=1",
+                ]
+                + vocab_args
+                + (extra or [])
+            ),
+        )
+
+    run_preprocess(processed_output_dir, featurized_output_dir)
 
     # Test data is composed of reactions for three most common templates in USPTO-50K, plus some
     # extra reactions using uncommon templates; the latter should get filtered out.
     assert get_num_lines(featurized_output_dir / "template_lib.json") == 3
     assert (featurized_output_dir / "data.h5").exists()
 
-    run_with_python(path="./retrochimera/cli/train.py", args=train_args)
+    run_train(featurized_output_dir, checkpoint_dir, log_dir)
 
     # As many best checkpoints as specified via `num_checkpoints_for_averaging`.
     assert get_num_files(checkpoint_dir / "best") == 2
@@ -295,15 +321,75 @@ def test_preprocess_and_train(
         extra_args=extra_args,
     )
 
+    # Next, test that the pretrained checkpoint can be fine-tuned on `pista_test.smi`.
+    finetune_split_dir = tmp_path / f"finetune_split_{testcase}"
+    finetune_split_dir.mkdir()
+    test_reactions = (split_output_dir / "pista_test.smi").read_text().splitlines()
+    for split_fold in ["train", "val", "test"]:
+        (finetune_split_dir / f"pista_{split_fold}.smi").write_text(
+            "\n".join(test_reactions) + "\n"
+        )
 
-def check_model_eval(
+    finetune_processed_dir = tmp_path / f"finetune_processed_{testcase}"
+    run_with_python(
+        path="./retrochimera/cli/extract_templates.py",
+        args=[f"data_dir={finetune_split_dir}", f"output_dir={finetune_processed_dir}"],
+    )
+
+    finetune_train_path = finetune_processed_dir / "train.jsonl"
+    finetune_lines = finetune_train_path.read_text().splitlines(keepends=True)[:NUM_SAMPLES]
+    finetune_train_path.write_text("".join(finetune_lines))
+    for split_fold in ["val", "test"]:
+        shutil.copy(finetune_train_path, finetune_processed_dir / f"{split_fold}.jsonl")
+
+    # Check how well the pretrained model already does on the held-out reactions.
+    pretrained_results = run_eval(
+        eval_model_class=eval_model_class,
+        model_dir=checkpoint_dir,
+        data_dir=finetune_processed_dir,
+        eval_results_dir=tmp_path / f"finetune_eval_pretrained_{testcase}",
+        extra_args=extra_args,
+    )
+
+    finetune_featurized_dir = tmp_path / f"finetune_featurized_{testcase}"
+    finetune_checkpoint_dir = tmp_path / f"finetune_checkpoint_{testcase}"
+
+    run_preprocess(finetune_processed_dir, finetune_featurized_dir)
+
+    # The held-out reactions yield a different template library than the pretraining data, so
+    # fine-tuning rebuilds the model's prediction head for a new label space.
+    assert (finetune_featurized_dir / "template_lib.json").read_text() != (
+        featurized_output_dir / "template_lib.json"
+    ).read_text()
+
+    run_train(
+        finetune_featurized_dir,
+        finetune_checkpoint_dir,
+        tmp_path / f"finetune_logs_{testcase}",
+        check_val_every_n_epoch=n_epochs // 2,
+        extra=[f"finetune_checkpoint_path={checkpoint_dir / 'combined.ckpt'}"],
+    )
+
+    finetuned_results = run_eval(
+        eval_model_class=eval_model_class,
+        model_dir=finetune_checkpoint_dir,
+        data_dir=finetune_processed_dir,
+        eval_results_dir=tmp_path / f"finetune_eval_finetuned_{testcase}",
+        extra_args=extra_args,
+    )
+
+    # Fine-tuning should improve accuracy on the held-out reactions.
+    assert finetuned_results["top_k"][0] > pretrained_results["top_k"][0]
+
+
+def run_eval(
     eval_model_class: str,
     model_dir: Path,
     data_dir: Path,
     eval_results_dir: Path,
     extra_args: Optional[list[str]] = None,
-) -> None:
-    """Run model evaluation and check the results."""
+) -> dict[str, Any]:
+    """Run model evaluation and return the parsed results."""
     eval_args = [
         f"model_class={eval_model_class}",
         f"model_dir={model_dir}",
@@ -323,6 +409,19 @@ def check_model_eval(
     assert eval_results["eval_args"]["model_class"] == f"{eval_model_class}Model"
     assert eval_results["eval_args"]["fold"] == "TEST"
     assert eval_results["num_samples"] == NUM_SAMPLES
+
+    return eval_results
+
+
+def check_model_eval(
+    eval_model_class: str,
+    model_dir: Path,
+    data_dir: Path,
+    eval_results_dir: Path,
+    extra_args: Optional[list[str]] = None,
+) -> None:
+    """Run model evaluation and check the results."""
+    eval_results = run_eval(eval_model_class, model_dir, data_dir, eval_results_dir, extra_args)
 
     # In this example, all template-based are capped at ~90% due to a small fraction of examples
     # using out-of-library templates. They should however be able to overfit the rest.


### PR DESCRIPTION
When attempting to train RetroChimera on a new dataset, it is very useful to be able to warm-start training by starting from the Pistachio-trained checkpoint. In internal tests, this can both improve the final quality of the model, and allow for getting there in 6x fewer training epochs.

This PR adds support for model finetuning to `cli/train.py`. Notably, it extends all model classes with a notion of "non-transferable prefixes", which are layers whose sizes depend on dataset metadata (e.g. size of template library or SMILES token vocabulary); those layers are not copied over, and instead are reinitialized from scratch. Initially (for `finetuning_warmup_epochs` epochs), only the reinitialized parameters are trained; after that, all parameters are unfrozen, and training proceeds as normal.

Additionally, this PR also extends the integration test to cover the new feature, and mentions it in workflow docs in `retrochimera/README.md`.