### PR TITLE
Disable sharded repodata in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           pre-commit run --verbose --all-files
   tests:
     runs-on: ubuntu-latest
+    env:
+      # Temporarily disable sharded repodata until fixed upstream.
+      MAMBA_USE_SHARDED_REPODATA: "false"
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Recently, our CI started failing from `main`, with errors in mamba env resolution. This turns out to be related to the handling of repodata information by the newest version of `mamba`. This PR disables the new behaviour, reverting to the old resolution method (whose only disadvantage is being slightly slower). We can remove this later once the new behaviour is stable.