### PR TITLE
Expose the forward model class externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Added
 
 - Add support for model finetuning ([#21](https://github.com/microsoft/retrochimera/pull/21)) ([@kmaziarz])
+- Expose the forward model class externally ([#23](https://github.com/microsoft/retrochimera/pull/23)) ([@kmaziarz])
 
 ## [1.2.0] - 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ For benchmarking, we also provide (weaker) checkpoints trained on [USPTO-50K](ht
 If you care about reproducing the USPTO-* results from our paper _exactly_, make sure to use the inference hyperparameters listed in Extended Data Tables 3 and 4.
 By default, these parameters are set to values optimal for the Pistachio checkpoint.
 
+Finally, we additionally release a [forward model checkpoint](https://figshare.com/ndownloader/files/66654872), which shares the same architecture as the SMILES-based submodel in RetroChimera, and was also trained on Pistachio.
+
 > [!WARNING]
 > RetroChimera 1 is being released for research and experimentation - we hope you try to break it in any way possible and share the results back to us. As any ML model it is **not free from errors and may hallucinate**, in particular when used for inputs out of the training distribution. We look forward to collaborating with the community so we can improve the model for everyone!
 >

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ The main (and most powerful) checkpoint we release is trained on [Pistachio](htt
 For benchmarking, we also provide (weaker) checkpoints trained on [USPTO-50K](https://figshare.com/ndownloader/files/59511926) and [USPTO-FULL](https://figshare.com/ndownloader/files/59494598).
 
 If you care about reproducing the USPTO-* results from our paper _exactly_, make sure to use the inference hyperparameters listed in Extended Data Tables 3 and 4.
-By default, these parameters are set to values optimal for the Pistachio checkpoint.
+By default, these parameters are set to values optimized for the Pistachio checkpoint.
 
-Finally, we additionally release a [forward model checkpoint](https://figshare.com/ndownloader/files/66654872), which shares the same architecture as the SMILES-based submodel in RetroChimera, and was also trained on Pistachio.
+Finally, we release a [forward model checkpoint](https://figshare.com/ndownloader/files/66654872), which uses the same architecture as the SMILES-based submodel of RetroChimera and was also trained on Pistachio.
 
 > [!WARNING]
 > RetroChimera 1 is being released for research and experimentation - we hope you try to break it in any way possible and share the results back to us. As any ML model it is **not free from errors and may hallucinate**, in particular when used for inputs out of the training distribution. We look forward to collaborating with the community so we can improve the model for everyone!

--- a/retrochimera/__init__.py
+++ b/retrochimera/__init__.py
@@ -6,6 +6,7 @@ os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
 from retrochimera.inference import (
     BasicTemplateClassificationModel,
+    ForwardChimeraDeNovoModel,
     RetroChimeraDeNovoModel,
     RetroChimeraEditModel,
     RetroChimeraModel,
@@ -13,6 +14,7 @@ from retrochimera.inference import (
 
 __all__ = [
     "BasicTemplateClassificationModel",
+    "ForwardChimeraDeNovoModel",
     "RetroChimeraDeNovoModel",
     "RetroChimeraEditModel",
     "RetroChimeraModel",

--- a/retrochimera/inference/__init__.py
+++ b/retrochimera/inference/__init__.py
@@ -1,10 +1,15 @@
 from retrochimera.inference.retrochimera import RetroChimeraModel
 from retrochimera.inference.smiles_transformer import SmilesTransformerModel
+from retrochimera.inference.smiles_transformer_forward import SmilesTransformerForwardModel
 from retrochimera.inference.template_classification import TemplateClassificationModel
 from retrochimera.inference.template_localization import TemplateLocalizationModel
 
 
 class BasicTemplateClassificationModel(TemplateClassificationModel):
+    pass
+
+
+class ForwardChimeraDeNovoModel(SmilesTransformerForwardModel):
     pass
 
 
@@ -18,10 +23,12 @@ class RetroChimeraEditModel(TemplateLocalizationModel):
 
 __all__ = [
     "BasicTemplateClassificationModel",
+    "ForwardChimeraDeNovoModel",
     "RetroChimeraDeNovoModel",
     "RetroChimeraEditModel",
     "RetroChimeraModel",
     "SmilesTransformerModel",
+    "SmilesTransformerForwardModel",
     "TemplateClassificationModel",
     "TemplateLocalizationModel",
 ]


### PR DESCRIPTION
In #9, we externally exposed the model classes so that they can be easily imported upon installing `retrochimera`. We however did not expose the forward model class `SmilesTransformerForwardModel`, and having that explicitly visible is useful downstream, for example for filtering backward proposals in `syntheseus`. This PR amends it, exposing the forward model class under the name `ForwardChimeraDeNovoModel`.