### PR TITLE
Handle finetuning of graphium-based models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add support for model finetuning ([#21](https://github.com/microsoft/retrochimera/pull/21)) ([@kmaziarz])
+- Add support for model finetuning ([#21](https://github.com/microsoft/retrochimera/pull/21), [#24](https://github.com/microsoft/retrochimera/pull/24)) ([@kmaziarz])
 - Expose the forward model class externally ([#23](https://github.com/microsoft/retrochimera/pull/23)) ([@kmaziarz])
 
 ## [1.2.0] - 2026-06-17

--- a/retrochimera/models/template_localization.py
+++ b/retrochimera/models/template_localization.py
@@ -569,6 +569,8 @@ class TemplateLocalizationModel(AbstractModel[TemplateReactionSample, ProcessedS
         # Add rewrite_encoder's non-transferable prefixes
         if self.rewrite_encoder.atom_categorical_features_emb is not None:
             prefixes.append("rewrite_encoder.atom_categorical_features_emb.")
+        elif self.rewrite_encoder._use_graphium:
+            prefixes.append("rewrite_encoder.gnn.pre_nn.")
         else:
             prefixes.append("rewrite_encoder.gnn.convs.0.")
 


### PR DESCRIPTION
In #21 we implemented model finetuning. However, one case that was missed was models based on the GPS layer from `graphium`. While this layer was not used for the Pistachio-based model, and hence not hugely important, it was used for the smaller USPTO-50K-based checkpoint, and is generally a supported setting in the codebase, so it's best to have finetuning also work. This PR fixes the non-transferable prefixes definition to cover GPS-based models.