### PR TITLE
Update `protobuf` dependency to 5.29.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update `protobuf` dependency to 5.29.6 ([#25](https://github.com/microsoft/retrochimera/pull/25)) ([@kmaziarz])
+
 ### Added
 
 - Add support for model finetuning ([#21](https://github.com/microsoft/retrochimera/pull/21), [#24](https://github.com/microsoft/retrochimera/pull/24)) ([@kmaziarz])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "joblib",
     "more_itertools",
     "omegaconf",
-    "protobuf==5.29.3",
+    "protobuf==5.29.6",
     "pydantic~=2.0",
     "pyopenssl>=23.0.0",
     "scikit-learn",


### PR DESCRIPTION
Dependabot highlighted that the version of `protobuf` we pin to, 5.29.3, has some security issues, and recommended updating to 5.29.6. I think these issues are not relevant in our context, but it doesn't hurt to bump the version anyway to resolve the alerts. In local tests there seem to be no behaviour changes (as expected, since `protobuf` is only a light transitive dependency, and we are only bumping it by a few patch versions).

_Note: This version of `protobuf` is still much behind the latest one (currently 7.35.1), but updating further would be a larger effort, requiring also upgrading other dependencies in tandem, e.g. `wandb`._