### PR TITLE
Implement consensus mode for ensembling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Added
 
 - Add support for model finetuning ([#21](https://github.com/microsoft/retrochimera/pull/21), [#24](https://github.com/microsoft/retrochimera/pull/24)) ([@kmaziarz])
+- Implement consensus mode for ensembling ([#26](https://github.com/microsoft/retrochimera/pull/26)) ([@kmaziarz])
 - Expose the forward model class externally ([#23](https://github.com/microsoft/retrochimera/pull/23)) ([@kmaziarz])
 
 ## [1.2.0] - 2026-06-17

--- a/retrochimera/inference/retrochimera.py
+++ b/retrochimera/inference/retrochimera.py
@@ -26,6 +26,7 @@ class RetroChimeraModel(ExternalBackwardReactionModel):
         *args,
         model_dir: Optional[Union[str, Path]] = None,
         probability_from_score_temperature: float = 8.0,
+        consensus_only: bool = False,
         call_submodels_in_parallel: bool = True,
         **kwargs,
     ) -> None:
@@ -59,6 +60,8 @@ class RetroChimeraModel(ExternalBackwardReactionModel):
 
         self._init_from_dir(model_dir=model_dir, model_data=model_data, model_kwargs=model_kwargs)
         self.probability_from_score_temperature = probability_from_score_temperature
+        self.consensus_only = consensus_only
+
         self._call_submodels_in_parallel = call_submodels_in_parallel
 
         if not self._models:
@@ -134,6 +137,7 @@ class RetroChimeraModel(ExternalBackwardReactionModel):
                 num_results=num_results,
                 model_names=self._model_names,
                 probability_from_score_temperature=self.probability_from_score_temperature,
+                consensus_only=self.consensus_only,
             )
             for input, model_results in zip(inputs, zip(*model_batch_results))
         ]
@@ -146,6 +150,7 @@ def combine_results(
     num_results: int,
     model_names: Optional[list[str]] = None,
     probability_from_score_temperature: Optional[float] = None,
+    consensus_only: bool = False,
 ) -> list[SingleProductReaction]:
     # Generate default model names if not provided.
     model_names = model_names or [f"model_{i}" for i in range(len(model_results))]
@@ -161,6 +166,14 @@ def combine_results(
         for rank, r in enumerate(results):
             result_to_ranks[r.reactants][model_idx] = rank
             result_to_metadata[r.reactants][model_idx] = r.metadata
+
+    if consensus_only:
+        result_to_ranks = {
+            result: ranks
+            for result, ranks in result_to_ranks.items()
+            if all(r is not None for r in ranks)
+        }
+        result_to_metadata = {result: result_to_metadata[result] for result in result_to_ranks}
 
     result_to_score: dict[Bag[Molecule], float] = {}
     for result, ranks in result_to_ranks.items():

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -536,3 +536,12 @@ def test_optimize_ensembles(tmp_path: Path, processed_output_dir: Path) -> None:
         data_dir=processed_output_dir,
         eval_results_dir=tmp_path / "eval_results_ensemble",
     )
+
+    # Re-run eval on the same ensemble checkpoint but restricting to consensus predictions only.
+    check_model_eval(
+        eval_model_class="RetroChimera",
+        model_dir=ensemble_checkpoint_full_dir,
+        data_dir=processed_output_dir,
+        eval_results_dir=tmp_path / "eval_results_ensemble_consensus_only",
+        extra_args=["model_kwargs={'consensus_only': True}"],
+    )


### PR DESCRIPTION
In recent experiments, we found one way to ensure higher prediction quality is to use a stricter version of ensembling, here referred to as _consensus mode_. In this setting, we rerank predictions as normal, but those that were not predicted by one of the submodels are skipped entirely. This PR adds this feature to the `RetroChimeraModel` class, hidden behind an init flag which is `False` by default.