### PR TITLE
Remove dependency on `syntheseus-root-aligned` and vendor relevant utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Remove dependency on `syntheseus-root-aligned` and vendor relevant utils ([#27](https://github.com/microsoft/retrochimera/pull/27)) ([@lgeiger])
 - Update `protobuf` dependency to 5.29.6 ([#25](https://github.com/microsoft/retrochimera/pull/25)) ([@kmaziarz])
 
 ### Added
@@ -51,3 +52,4 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 [1.2.0]: https://github.com/microsoft/retrochimera/releases/tag/v1.2.0
 
 [@kmaziarz]: https://github.com/kmaziarz
+[@lgeiger]: https://github.com/lgeiger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "pyopenssl>=23.0.0",
     "scikit-learn",
     "syntheseus>=0.7.2",
-    "syntheseus-root-aligned==0.2.0",
     "tqdm",
     "wandb==0.17.7",
 ]
@@ -77,7 +76,6 @@ module = [
     "joblib.*",
     "pandas.*",
     "rdchiral.*",
-    "root_aligned.*",
     "scipy.*",
     "torch_geometric.*",
     "tqdm.*",

--- a/retrochimera/cli/augment_rsmiles.py
+++ b/retrochimera/cli/augment_rsmiles.py
@@ -19,7 +19,12 @@ from syntheseus.reaction_prediction.utils.config import get_config as cli_get_co
 from tqdm import tqdm
 
 from retrochimera.utils.logging import get_logger
-from retrochimera.utils.root_aligned import get_product_roots
+from retrochimera.utils.root_aligned import (
+    clear_map_canonical_smiles,
+    get_cano_map_number,
+    get_product_roots,
+    get_root_id,
+)
 
 RDLogger.DisableLog("rdApp.*")
 
@@ -40,12 +45,6 @@ class AugmentRSMILESConfig:
 
 def multi_process(data: dict):
     """Multi-process function to process the data."""
-    from root_aligned.preprocessing.generate_PtoR_data import (
-        clear_map_canonical_smiles,
-        get_cano_map_number,
-        get_root_id,
-    )
-
     reaction = data["reaction"]
     augmentation = data["augmentation"]
 

--- a/retrochimera/inference/smiles_transformer.py
+++ b/retrochimera/inference/smiles_transformer.py
@@ -17,7 +17,7 @@ from syntheseus.reaction_prediction.utils.misc import suppress_outputs
 from retrochimera.models.smiles_transformer import SmilesTransformerModel as TransformerModel
 from retrochimera.opennmt.decode.translator import Translator
 from retrochimera.utils.logging import get_logger
-from retrochimera.utils.root_aligned import get_product_roots
+from retrochimera.utils.root_aligned import clear_map_canonical_smiles, get_product_roots
 
 logger = get_logger(__name__)
 
@@ -279,8 +279,6 @@ class SmilesTransformerModel(
     AbstractSmilesTransformerModel[Molecule, SingleProductReaction], ExternalBackwardReactionModel
 ):
     def _augment_input(self, input: Molecule) -> list[str]:
-        from root_aligned.preprocessing.generate_PtoR_data import clear_map_canonical_smiles
-
         augmented_input = []
 
         product_roots = get_product_roots(

--- a/retrochimera/inference/smiles_transformer_forward.py
+++ b/retrochimera/inference/smiles_transformer_forward.py
@@ -9,14 +9,13 @@ from syntheseus.reaction_prediction.inference_base import ExternalForwardReactio
 from syntheseus.reaction_prediction.utils.inference import process_raw_smiles_outputs_forwards
 
 from retrochimera.inference.smiles_transformer import AbstractSmilesTransformerModel
+from retrochimera.utils.root_aligned import clear_map_canonical_smiles
 
 
 class SmilesTransformerForwardModel(
     AbstractSmilesTransformerModel[Bag[Molecule], Reaction], ExternalForwardReactionModel
 ):
     def _augment_input(self, input: Bag[Molecule]) -> list[str]:
-        from root_aligned.preprocessing.generate_PtoR_data import clear_map_canonical_smiles
-
         augmented_input = []
 
         # Obtain `reactant_roots`

--- a/retrochimera/utils/root_aligned.py
+++ b/retrochimera/utils/root_aligned.py
@@ -1,4 +1,13 @@
+"""RootAligned utilities
+
+Code for clear_map_canonical_smiles, get_cano_map_number, and get_root_id from
+https://github.com/otori-bird/retrosynthesis/blob/main/preprocessing/generate_PtoR_data.py
+"""
+
 import random
+
+import numpy as np
+from rdkit import Chem
 
 
 def get_product_roots(product_atom_ids: list[int], num_augmentations: int) -> list[int]:
@@ -14,3 +23,44 @@ def get_product_roots(product_atom_ids: list[int], num_augmentations: int) -> li
 
     assert len(product_roots) == num_augmentations
     return product_roots
+
+
+def clear_map_canonical_smiles(smi, canonical=True, root=-1):
+    mol = Chem.MolFromSmiles(smi)
+    if mol is not None:
+        for atom in mol.GetAtoms():
+            if atom.HasProp("molAtomMapNumber"):
+                atom.ClearProp("molAtomMapNumber")
+        return Chem.MolToSmiles(mol, isomericSmiles=True, rootedAtAtom=root, canonical=canonical)
+    else:
+        return smi
+
+
+def get_cano_map_number(smi, root=-1):
+    atommap_mol = Chem.MolFromSmiles(smi)
+    canonical_mol = Chem.MolFromSmiles(clear_map_canonical_smiles(smi, root=root))
+    cano2atommapIdx = atommap_mol.GetSubstructMatch(canonical_mol)
+    correct_mapped = [
+        canonical_mol.GetAtomWithIdx(i).GetSymbol() == atommap_mol.GetAtomWithIdx(index).GetSymbol()
+        for i, index in enumerate(cano2atommapIdx)
+    ]
+    atom_number = len(canonical_mol.GetAtoms())
+    if np.sum(correct_mapped) < atom_number or len(cano2atommapIdx) < atom_number:
+        cano2atommapIdx = [0] * atom_number
+        atommap2canoIdx = canonical_mol.GetSubstructMatch(atommap_mol)
+        if len(atommap2canoIdx) != atom_number:
+            return None
+        for i, index in enumerate(atommap2canoIdx):
+            cano2atommapIdx[index] = i
+    id2atommap = [atom.GetAtomMapNum() for atom in atommap_mol.GetAtoms()]
+
+    return [id2atommap[cano2atommapIdx[i]] for i in range(atom_number)]
+
+
+def get_root_id(mol, root_map_number):
+    root = -1
+    for i, atom in enumerate(mol.GetAtoms()):
+        if atom.GetAtomMapNum() == root_map_number:
+            root = i
+            break
+    return root


### PR DESCRIPTION
RetroChimera currently depends on `syntheseus-root-aligned` for 3 utility functions. The package has a dependency on [OpenNMT-py](https://github.com/kmaziarz/RootAligned/blob/main/pyproject.toml#L6) which depends on quite a few [other packages](https://github.com/OpenNMT/OpenNMT-py/blob/97111d97551c24857076a4102eabdb468b35cff4/setup.py#L23-L38) that don't play well with modern Python versions and forces us to use older versions of torch.

This PR vendors the utility functions for root alignment so we don't need to pull in all the dependencies. An alternative would be to make the [inference/training related dependencies from `syntheseus-root-aligned`](https://github.com/kmaziarz/RootAligned/blob/main/pyproject.toml#L5-L9) optional. Though I think in this case it's probably worth accepting a small bit of code duplication in favour of less dependencies.