### PR TITLE
Do not load template RuleBase in SmilesTransformer training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Make template extraction more robust ([#28](https://github.com/microsoft/retrochimera/pull/28)) ([@kmaziarz])
 - Remove dependency on `syntheseus-root-aligned` and vendor relevant utils ([#27](https://github.com/microsoft/retrochimera/pull/27)) ([@lgeiger])
-- Do not load template RuleBase in SmilesTransformer training ([#29](https://github.com/microsoft/retrochimera/pull/29) ([@lgeiger])
+- Do not load template library in SMILES Transformer training ([#29](https://github.com/microsoft/retrochimera/pull/29)) ([@lgeiger])
 - Update `protobuf` dependency to 5.29.6 ([#25](https://github.com/microsoft/retrochimera/pull/25)) ([@kmaziarz])
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Make template extraction more robust ([#28](https://github.com/microsoft/retrochimera/pull/28)) ([@kmaziarz])
 - Remove dependency on `syntheseus-root-aligned` and vendor relevant utils ([#27](https://github.com/microsoft/retrochimera/pull/27)) ([@lgeiger])
+- Do not load template RuleBase in SmilesTransformer training ([#29](https://github.com/microsoft/retrochimera/pull/29) ([@lgeiger])
 - Update `protobuf` dependency to 5.29.6 ([#25](https://github.com/microsoft/retrochimera/pull/25)) ([@kmaziarz])
 
 ### Added

--- a/retrochimera/cli/train.py
+++ b/retrochimera/cli/train.py
@@ -380,7 +380,7 @@ def train(
 
 
 def build_model_from_config(
-    config: ModelTrainingConfig, rulebase: RuleBase, rulebase_dir: Union[str, Path]
+    config: ModelTrainingConfig, rulebase: Optional[RuleBase], rulebase_dir: Union[str, Path]
 ) -> tuple[AbstractModel, Any]:
     model_class: Any = None
     model_config: Any = None
@@ -427,6 +427,7 @@ def build_model_from_config(
         )
 
         # Look through the rulebase to build the featurizer kwargs (e.g. atom SMARTS vocabulary).
+        assert rulebase is not None
         rewrite_featurizer_kwargs = rewrite_featurizer_class.prepare_kwargs(
             rewrites=(rule.rxn for rule in rulebase.rules.values())
         )
@@ -440,7 +441,7 @@ def build_model_from_config(
     # Add model kwargs that are shared across all models classes.
     model_kwargs.update(
         {
-            "n_classes": len(rulebase),
+            "n_classes": len(rulebase) if rulebase is not None else 0,
             "learning_rate": model_config.training.learning_rate,
             "learning_rate_decay_step_size": model_config.training.learning_rate_decay_step_size,
             "learning_rate_decay_rate": model_config.training.learning_rate_decay_rate,
@@ -462,6 +463,7 @@ def build_model_from_config(
             "rewrite_encoder_num_epochs",
         ]
         model_kwargs.update({key: getattr(model_config, key) for key in keys})
+        assert rulebase is not None
         model_kwargs["num_total_rewrite_lhs_atoms"] = sum(
             rule.rxn.rdkit_lhs_mol.GetNumAtoms() for rule in rulebase.rules.values()
         )
@@ -504,7 +506,8 @@ def build_model_from_config(
     logger.info(f"Building the model {config.model_class} with kwargs {model_kwargs}")
 
     model = model_class(**model_kwargs)
-    model.set_rulebase(rulebase=rulebase, rulebase_dir=rulebase_dir)
+    if not isinstance(model, SmilesTransformerModel):
+        model.set_rulebase(rulebase=rulebase, rulebase_dir=rulebase_dir)
 
     return model, model_config
 
@@ -546,27 +549,24 @@ def main() -> None:
     set_random_seed(config.seed)
 
     processed_data_dir = Path(config.processed_data_dir)
-    processed_rulebase_path = processed_data_dir / RuleBase.DEFAULT_FILE_NAME
-
     checkpoint_dir = Path(config.checkpoint_dir)
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
-    checkpoint_rulebase_path = checkpoint_dir / RuleBase.DEFAULT_FILE_NAME
-
-    # Copy the rulebase into the checkpoint directory, which is only done by the first process
-    # (other training processes will be spawned in `train`).
-    if not checkpoint_rulebase_path.exists():
-        logger.info(f"Copying the rulebase into {config.checkpoint_dir}")
-        shutil.copy(processed_rulebase_path, checkpoint_rulebase_path)
 
     if config.model_class is ModelClass.SmilesTransformer:
-        rulebase = RuleBase()
         checkpoint_vocab_path = checkpoint_dir / SmilesTransformerModel.DEFAULT_VOCAB_FILE_NAME
-
+        rulebase = None
         if not checkpoint_vocab_path.exists():
             # For the SMILES Transformer we also copy the vocab file.
             logger.info(f"Copying the vocab file into {config.checkpoint_dir}")
             shutil.copy(config.smiles_transformer_config.vocab_path, checkpoint_vocab_path)
     else:
+        processed_rulebase_path = processed_data_dir / RuleBase.DEFAULT_FILE_NAME
+        checkpoint_rulebase_path = checkpoint_dir / RuleBase.DEFAULT_FILE_NAME
+        # Copy the rulebase into the checkpoint directory, which is only done by the first process
+        # (other training processes will be spawned in `train`).
+        if not checkpoint_rulebase_path.exists():
+            logger.info(f"Copying the rulebase into {config.checkpoint_dir}")
+            shutil.copy(processed_rulebase_path, checkpoint_rulebase_path)
         rulebase = RuleBase.load_from_file(dir=checkpoint_dir)
 
     model, model_config = build_model_from_config(

--- a/retrochimera/cli/train.py
+++ b/retrochimera/cli/train.py
@@ -559,17 +559,18 @@ def main() -> None:
         shutil.copy(processed_rulebase_path, checkpoint_rulebase_path)
 
     if config.model_class is ModelClass.SmilesTransformer:
+        rulebase = RuleBase()
         checkpoint_vocab_path = checkpoint_dir / SmilesTransformerModel.DEFAULT_VOCAB_FILE_NAME
 
         if not checkpoint_vocab_path.exists():
             # For the SMILES Transformer we also copy the vocab file.
             logger.info(f"Copying the vocab file into {config.checkpoint_dir}")
             shutil.copy(config.smiles_transformer_config.vocab_path, checkpoint_vocab_path)
+    else:
+        rulebase = RuleBase.load_from_file(dir=checkpoint_dir)
 
     model, model_config = build_model_from_config(
-        config=config,
-        rulebase=RuleBase.load_from_file(dir=checkpoint_dir),
-        rulebase_dir=checkpoint_dir,
+        config=config, rulebase=rulebase, rulebase_dir=checkpoint_dir
     )
 
     # Handle fine-tuning from a pretrained checkpoint

--- a/retrochimera/cli/train.py
+++ b/retrochimera/cli/train.py
@@ -506,7 +506,7 @@ def build_model_from_config(
     logger.info(f"Building the model {config.model_class} with kwargs {model_kwargs}")
 
     model = model_class(**model_kwargs)
-    if not isinstance(model, SmilesTransformerModel):
+    if config.model_class is not ModelClass.SmilesTransformer:
         model.set_rulebase(rulebase=rulebase, rulebase_dir=rulebase_dir)
 
     return model, model_config

--- a/retrochimera/data/preprocessing/smiles_transformer.py
+++ b/retrochimera/data/preprocessing/smiles_transformer.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from functools import partial
-from pathlib import Path
-from typing import Iterable, Union
+from typing import Iterable
 
 from syntheseus.reaction_prediction.utils.misc import parallelize
 
@@ -34,7 +33,6 @@ def _process_sample(
 
 def preprocess_samples(
     samples: Iterable[SmilesReactionSample],
-    rulebase_dir: Union[str, Path],
     tokenizer: Tokenizer,
     num_processes: int,
 ) -> Iterable[ProcessedSample]:

--- a/retrochimera/models/smiles_transformer.py
+++ b/retrochimera/models/smiles_transformer.py
@@ -1,7 +1,6 @@
 import math
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Iterable, Optional, Union
+from typing import Iterable, Optional
 
 import torch
 from more_itertools import batched
@@ -9,7 +8,6 @@ from torch import nn
 from torch.nn.init import xavier_uniform_, zeros_
 from torch.optim.lr_scheduler import OneCycleLR
 
-from retrochimera.chem.rules import RuleBase
 from retrochimera.data.preprocessing.smiles_transformer import ProcessedSample, preprocess_samples
 from retrochimera.data.smiles_reaction_sample import SmilesReactionSample
 from retrochimera.data.smiles_tokenizer import Tokenizer
@@ -690,15 +688,8 @@ class SmilesTransformerModel(AbstractModel[SmilesReactionSample, ProcessedSample
         self, samples: Iterable[SmilesReactionSample], num_processes: int = 0
     ) -> Iterable[ProcessedSample]:
         yield from preprocess_samples(
-            samples=samples,
-            rulebase_dir=self.rulebase_dir,
-            tokenizer=self.tokenizer,
-            num_processes=num_processes,
+            samples=samples, tokenizer=self.tokenizer, num_processes=num_processes
         )
-
-    def set_rulebase(self, rulebase: RuleBase, rulebase_dir: Union[str, Path]) -> None:
-        # Inherited from other template-based models (Not used in this model now)
-        self.rulebase_dir = rulebase_dir
 
     def get_nontransferable_param_prefixes(self) -> list[str]:
         prefixes = ["token_fc."]


### PR DESCRIPTION
Constructing the rule base can take a long time. As far as I can tell this is not used during the Smiles Transformer training. This PR changes the training code to pass a dummy rule base during the transformer training such that training doesn't need to wait for the rule base to be loaded from file.