### PR TITLE
Improve the ensemble optimization script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Add support for model finetuning ([#21](https://github.com/microsoft/retrochimera/pull/21), [#24](https://github.com/microsoft/retrochimera/pull/24)) ([@kmaziarz])
 - Implement consensus mode for ensembling ([#26](https://github.com/microsoft/retrochimera/pull/26)) ([@kmaziarz])
+- Allow ensembling to consume eval outputs produced in resumable mode ([#32](https://github.com/microsoft/retrochimera/pull/32)) ([@kmaziarz])
 - Expose the forward model class externally ([#23](https://github.com/microsoft/retrochimera/pull/23)) ([@kmaziarz])
 
 ## [1.2.0] - 2026-06-17

--- a/retrochimera/cli/optimize_ensembles.py
+++ b/retrochimera/cli/optimize_ensembles.py
@@ -61,10 +61,23 @@ def load_ground_truths(
     return {fold: [(r.products, r.reactants) for r in dataset[fold]] for fold in folds}
 
 
-def load_predicted_reactants(data: dict[str, Any]) -> list[list[list[Molecule]]]:
+def load_predicted_reactants(
+    data: dict[str, Any],
+    ground_truth_products: list[Bag[Molecule]],
+    offset: int = 0,
+) -> list[list[list[Molecule]]]:
     raw_reactants: list[list[list[Molecule]]] = []
-    for predictions in data["predictions"]:
+    for i, predictions in enumerate(data["predictions"]):
         if isinstance(predictions, dict):
+            input_smiles = predictions.get("input")
+            if input_smiles is not None:
+                expected = ground_truth_products[offset + i]
+                actual = Bag([make_mol(input_smiles)])
+                assert actual == expected, (
+                    f"Prediction {offset + i}: input '{input_smiles}' does not match "
+                    f"expected product '{expected}'"
+                )
+
             predictions = predictions["predictions"]  # Handle older output format.
 
         raw_reactants.append(  # Handle older output format.
@@ -242,11 +255,14 @@ def run_from_config(config: EvalEnsemblesConfig) -> None:
     output_dir = Path(config.output_dir)
 
     logger.info(f"Loading dataset ground truths from {config.data_dir}")
+    all_ground_truths = load_ground_truths(
+        data_dir=config.data_dir, folds=[DataFold.VALIDATION, DataFold.TEST]
+    )
     ground_truths = {
-        fold: [reactants for _, reactants in samples]
-        for fold, samples in load_ground_truths(
-            data_dir=config.data_dir, folds=[DataFold.VALIDATION, DataFold.TEST]
-        ).items()
+        fold: [reactants for _, reactants in samples] for fold, samples in all_ground_truths.items()
+    }
+    ground_truth_products = {
+        fold: [products for products, _ in samples] for fold, samples in all_ground_truths.items()
     }
 
     # If the results for some of the models are split into subdirectories, make sure these are
@@ -312,7 +328,8 @@ def run_from_config(config: EvalEnsemblesConfig) -> None:
                     num_samples_2=len(data["predictions"]),
                 )
 
-            for reactants in load_predicted_reactants(data):
+            offset = len(model_to_fold_to_results[model_class][fold])
+            for reactants in load_predicted_reactants(data, ground_truth_products[fold], offset):
                 model_to_fold_to_results[model_class][fold].append([Bag(r) for r in reactants])
 
     models_to_ensemble: list[str] = []

--- a/retrochimera/cli/optimize_ensembles.py
+++ b/retrochimera/cli/optimize_ensembles.py
@@ -268,7 +268,11 @@ def run_from_config(config: EvalEnsemblesConfig) -> None:
     # If the results for some of the models are split into subdirectories, make sure these are
     # processed in correct order (we assume a naming scheme of the form `...1`, `...2`, etc).
     result_paths = sorted(
-        glob.glob(f"{config.results_dir}/**/eval_results_{config.dataset}/*.json", recursive=True)
+        dict.fromkeys(
+            glob.glob(
+                f"{config.results_dir}/**/eval_results_{config.dataset}/**/*.json", recursive=True
+            )
+        )
     )
 
     result_paths_joined = "\n".join(result_paths)
@@ -298,7 +302,18 @@ def run_from_config(config: EvalEnsemblesConfig) -> None:
         with open(path, "rt") as f:
             data = json.load(f)
 
-            if not data["predictions"]:
+            # Check if predictions are stored in a separate .jsonl file in the same directory.
+            jsonl_files = list(Path(path).parent.glob("*.jsonl"))
+            if len(jsonl_files) > 1:
+                raise ValueError(f"Multiple .jsonl prediction files found for model {model_class}")
+
+            if jsonl_files:
+                [jsonl_path] = jsonl_files
+                logger.info(f"Detected resumable format; loading predictions from {jsonl_path}")
+                with open(jsonl_path, "rt") as f_predictions:
+                    data["predictions"] = [json.loads(line) for line in f_predictions]
+
+            if not data.get("predictions"):
                 continue
 
             args = data["eval_args"]


### PR DESCRIPTION
Since `syntheseus 0.8.0`, the library supports a new preemption-friendly resumable output format. As our ensemble optimization script consumes saved evaluation results, it depends on the format these are saved in. This PR extends that script to support the new format. Moreover, it also adds extra checks to verify the provided data is self-consistent (i.e. that the products in the provided ground-truth file match the ones recorded in the model outputs file).