### PR TITLE
Fix process leak in rule application server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Allow ensembling to consume eval outputs produced in resumable mode ([#32](https://github.com/microsoft/retrochimera/pull/32)) ([@kmaziarz])
 - Expose the forward model class externally ([#23](https://github.com/microsoft/retrochimera/pull/23)) ([@kmaziarz])
 
+### Fixed
+
+- Fix process leak in rule application server ([#33](https://github.com/microsoft/retrochimera/pull/33)) ([@kmaziarz])
+
 ## [1.2.0] - 2026-06-17
 
 ### Changed

--- a/retrochimera/chem/rule_application_server.py
+++ b/retrochimera/chem/rule_application_server.py
@@ -151,10 +151,21 @@ class RuleApplicationServer:
         for process_id in processes:
             # First wait to see if the process finishes gracefully; if not, SIGTERM it.
             processes[process_id].join(timeout=2.0)
-            processes[process_id].terminate()
+
+            if processes[process_id].is_alive():
+                processes[process_id].terminate()
 
         for process_id in processes:
             processes[process_id].join(timeout=2.0)
+
+            if processes[process_id].is_alive():
+                logger.warning(
+                    f"Rule application process {process_id} ignored SIGTERM; sending SIGKILL"
+                )
+                processes[process_id].kill()
+
+        for process_id in processes:
+            processes[process_id].join(timeout=5.0)
 
         for process_id in processes:
             try:

--- a/tests/chem/test_rule_application_server.py
+++ b/tests/chem/test_rule_application_server.py
@@ -1,7 +1,9 @@
 import gc
 import random
+import signal
 import tempfile
-from multiprocessing import active_children
+import time
+from multiprocessing import Event, Pipe, Process, active_children
 
 import pytest
 from syntheseus.reaction_prediction.data.reaction_sample import ReactionSample
@@ -63,3 +65,36 @@ def test_processes_cleaned_up_on_gc(tiny_rulebase):
     gc.collect()
 
     assert not workers_before & set(active_children())
+
+
+def _ignore_sigterm(ready) -> None:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    ready.set()
+
+    while True:
+        time.sleep(1.0)
+
+
+def test_processes_cleaned_up_when_sigterm_is_ignored():
+    """Verify that cleanup escalates when a worker does not respond to SIGTERM."""
+    parent_connection, child_connection = Pipe()
+    ready = Event()
+
+    worker = Process(target=_ignore_sigterm, args=(ready,))
+    worker.start()
+    child_connection.close()
+
+    try:
+        assert ready.wait(timeout=5.0)
+        RuleApplicationServer._finalize_server({0: worker}, {0: parent_connection})
+
+        # Check that the worker was killed and removed from the active children
+        assert worker not in active_children()
+    finally:
+        if worker in active_children():
+            # If we got here, the test failed; clean it up to avoid leaving a stray process running
+            worker.kill()
+            worker.join(timeout=2.0)
+            worker.close()
+
+        parent_connection.close()


### PR DESCRIPTION
For the template-based branch of RetroChimera, we use a `RuleApplicationServer` to launch parallel template application processes. In some cases, notably when dealing with highly symmetric templates or molecules, template application may hang, and the corresponding process has to be killed. In #14, we fixed an earlier bug, which was preventing process cleanup upon garbage collection. However, as reported by @jsmith13, there is another pitfall: we kill hanging processes via `terminate()`, which sends a `SIGTERM`, but in some cases a stubborn process can ignore this signal, and then the application server moves on, causing a memory leak. This PR first adds a test to illustrate the issue, and then fixes it by eventually escalating to `SIGKILL`, which cannot be ignored.